### PR TITLE
Reduce memory use of KTH data loader by factor 4

### DIFF
--- a/core/data_provider/kth_action.py
+++ b/core/data_provider/kth_action.py
@@ -5,6 +5,8 @@ import cv2
 from PIL import Image
 import logging
 import random
+from typing import Iterable, List
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,8 @@ class InputHandle:
             logger.error(
                 "There is no batch left in " + self.name + ". Consider to user iterators.begin() to rescan from the beginning of the iterators")
             return None
+        # Create batch of N videos of length L, i.e. shape = (N, L, w, h, c)
+        # where w x h is the resolution and c the number of color channels
         input_batch = np.zeros(
             (self.minibatch_size, self.current_input_length, self.image_width, self.image_width, 1)).astype(
             self.input_data_type)
@@ -68,20 +72,67 @@ class InputHandle:
         logger.info("    current_input_length: " + str(self.current_input_length))
         logger.info("    Input Data Type: " + str(self.input_data_type))
 
+
+@dataclass
+class ActionFrameInfo:
+    file_name: str
+    file_path: str
+    person_mark: int
+    category_flag: int
+
+
 class DataProcess:
     def __init__(self, input_param):
-        self.paths = input_param['paths']
+        self.paths = input_param['paths']  # path to parent folder containing category dirs
         self.category_1 = ['boxing', 'handclapping', 'handwaving', 'walking']
         self.category_2 = ['jogging', 'running']
-        self.category = self.category_1 + self.category_2
+        self.categories = self.category_1 + self.category_2
         self.image_width = input_param['image_width']
 
+        # Hard coded training and test persons (prevent same person occurring in train - test set)
         self.train_person = ['01', '02', '03', '04', '05', '06', '07', '08',
                              '09', '10', '11', '12', '13', '14', '15', '16']
         self.test_person = ['17', '18', '19', '20', '21', '22', '23', '24', '25']
 
         self.input_param = input_param
         self.seq_len = input_param['seq_length']
+
+
+    def generate_frames(self, root_path, person_ids: List[int]) -> Iterable[ActionFrameInfo]:
+        """Generate frame info for all frames.
+        
+        Parameters:
+            person_ids: persons to include
+        """
+        person_mark = 0
+        for cat_dir in self.categories: # handwaving
+            if cat_dir in self.category_1:
+                frame_category_flag = 1 # 20 step
+            elif cat_dir in self.category_2:
+                frame_category_flag = 2 # 3 step
+            else:
+                raise Exception("category error!!!")
+
+            cat_dir_path = os.path.join(root_path, cat_dir)
+            cat_videos = os.listdir(cat_dir_path)
+
+            for person_direction_video in cat_videos:
+                person_id = person_direction_video[6:8]  # chars 6-8 contan number
+                if person_id not in person_ids:
+                    continue
+                person_mark += 1  # identify all stored frames as belonging to this person + direction
+                dir_path = os.path.join(cat_dir_path, person_direction_video)
+                filelist = os.listdir(dir_path)
+                filelist.sort() 
+                for frame_name in filelist: 
+                    if frame_name.startswith('image') == False:
+                        continue
+                    yield ActionFrameInfo(
+                        file_name=frame_name,
+                        file_path=os.path.join(dir_path, frame_name),
+                        person_mark=person_mark,
+                        category_flag=frame_category_flag
+                    )
 
     def load_data(self, paths, mode='train'):
         '''
@@ -92,75 +143,65 @@ class DataProcess:
 
         path = paths[0]
         if mode == 'train':
-            person_id = self.train_person
+            mode_person_ids = self.train_person
         elif mode == 'test':
-            person_id = self.test_person
+            mode_person_ids = self.test_person
         else:
-            print("ERROR!")
+            raise Exception("Unexpected mode: " + mode)
         print('begin load data' + str(path))
 
-        frames_np = []
         frames_file_name = []
-        frames_person_mark = []
+        frames_person_mark = []  # for each frame in the joint array, mark the person ID
         frames_category = []
-        person_mark = 0
 
-        c_dir_list = self.category
-        frame_category_flag = -1
-        for c_dir in c_dir_list: # handwaving
-            if c_dir in self.category_1:
-                frame_category_flag = 1 # 20 step
-            elif c_dir in self.category_2:
-                frame_category_flag = 2 # 3 step
-            else:
-                print("category error!!!")
+        # First count total number of frames
+        # Do it without creating massive array:
+        # all_frame_info = self.generate_frames(path, mode_person_ids)
+        tot_num_frames = sum((1 for _ in self.generate_frames(path, mode_person_ids)))
+        print(f"Preparing to load {tot_num_frames} video frames.")
+        
+        # Target array containing ALL RESIZED frames
+        data = np.empty((tot_num_frames, self.image_width, self.image_width , 1),
+                        dtype=np.int8)  # np.float32
 
-            c_dir_path = os.path.join(path, c_dir)
-            p_c_dir_list = os.listdir(c_dir_path)
+        # Read, resize, and store video frames
+        for i, frame in enumerate(self.generate_frames(path, mode_person_ids)):
+            frame_im = Image.open(frame.file_path).convert('L') # int8 2D array
 
-            for p_c_dir in p_c_dir_list: 
-                if p_c_dir[6:8] not in person_id:
-                    continue
-                person_mark += 1
-                dir_path = os.path.join(c_dir_path, p_c_dir)
-                filelist = os.listdir(dir_path)
-                filelist.sort() 
-                for file in filelist: 
-                    if file.startswith('image') == False:
-                        continue
-                    # print(file)
-                    # print(os.path.join(dir_path, file))
-                    frame_im = Image.open(os.path.join(dir_path, file))
-                    frame_np = np.array(frame_im)  # (1000, 1000) numpy array
-                    # print(frame_np.shape)
-                    frame_np = frame_np[:, :, 0] #
-                    frames_np.append(frame_np)
-                    frames_file_name.append(file)
-                    frames_person_mark.append(person_mark)
-                    frames_category.append(frame_category_flag)
-        # is it a begin index of sequence
+            # input type must be float32 for default interpolation method cv2.INTER_AREA
+            frame_np = np.array(frame_im, dtype=np.float32)  # (1000, 1000) numpy array
+            data[i,:,:,0] = (cv2.resize(
+                frame_np, (self.image_width,self.image_width))/255).astype(np.int8)
+
+            frames_file_name.append(frame.file_name)
+            frames_person_mark.append(frame.person_mark)
+            frames_category.append(frame.category_flag)
+        
+        # identify sequences of <seq_len> within the same video
         indices = []
-        index = len(frames_person_mark) - 1
-        while index >= self.seq_len - 1:
-            if frames_person_mark[index] == frames_person_mark[index - self.seq_len + 1]:
-                end = int(frames_file_name[index][6:10])
-                start = int(frames_file_name[index - self.seq_len + 1][6:10])
+        seq_end_idx = len(frames_person_mark) - 1
+        while seq_end_idx >= self.seq_len - 1:
+            seq_start_idx = seq_end_idx - self.seq_len + 1
+            if frames_person_mark[seq_end_idx] == frames_person_mark[seq_start_idx]:
+                # Get person ID at the start and end of this sequence (of seq_len)
+                end = int(frames_file_name[seq_end_idx][6:10])
+                start = int(frames_file_name[seq_start_idx][6:10])
+                
                 # TODO: mode == 'test'
                 if end - start == self.seq_len - 1:
-                    indices.append(index - self.seq_len + 1)
-                    if frames_category[index] == 1:
-                        index -= self.seq_len - 1
-                    elif frames_category[index] == 2:
-                        index -= 2
-                    else:
-                        print("category error 2 !!!")
-            index -= 1
+                    # Save index into OUT data array indicating start point of sequence
+                    indices.append(seq_start_idx)
 
-        frames_np = np.asarray(frames_np)
-        data = np.zeros((frames_np.shape[0], self.image_width, self.image_width , 1))
-        for i in range(len(frames_np)):
-            temp = np.float32(frames_np[i, :, :])
-            data[i,:,:,0]=cv2.resize(temp,(self.image_width,self.image_width))/255
+                    # The step size depends on the category
+                    if frames_category[seq_end_idx] == 1:
+                        seq_end_idx -= self.seq_len - 1
+                    elif frames_category[seq_end_idx] == 2:
+                        seq_end_idx -= 2
+                    else:
+                        raise Exception("category error 2 !!!")
+            
+            seq_end_idx -= 1
+
         print("there are " + str(data.shape[0]) + " pictures")
         print("there are " + str(len(indices)) + " sequences")
         return data, indices


### PR DESCRIPTION
Hi there, this edit reduces the memory footprint of the KTH data loader by a factor of four. The original version did not run on systems with <= 16 GB, whereas this version does. Images are stored as grayscale int8 until they are loaded into a batch (since they are grayscale anyway).

This also makes the code suitable to be run on Google Colab (free version).