### PR TITLE
Update import

### DIFF
--- a/core/trainer.py
+++ b/core/trainer.py
@@ -2,7 +2,7 @@ import os.path
 import datetime
 import cv2
 import numpy as np
-from skimage.measure import compare_ssim
+from skimage.metrics import structural_similarity as compare_ssim
 from core.utils import preprocess, metrics
 import lpips
 import torch


### PR DESCRIPTION
"from skimage.measure import compare_ssim" is deprecated. Change it to: "from skimage.metrics import structural_similarity as compare_ssim"